### PR TITLE
Various CMakeLists.txt files fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,6 @@ if ( VALGRIND )
   set ( VALGRIND_CMD ${VALGRIND} --leak-check=full --show-leak-kinds=all )
 endif ( VALGRIND )
 
-set ( REDUCE ${VALGRIND_CMD} ../../../../vpmReducer/fedem_reducer )
-set ( SOLMAP ${VALGRIND_CMD} ../../../../SolutionMapper/fedem_solmap )
-set ( SOLVER ${VALGRIND_CMD} ../../../fedem_solver )
-
 add_custom_target ( copy_test_input_files )
 foreach ( TEST ${TEST_DIRS} )
   set ( BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TEST} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
+################################################################################
+# This cmake project file conducts the regression tests for the FEDEM solvers
+# using the ctest tool. The individual tests are located in subdirectories.
+# Notice that the input files of the tests are copied from the source tree
+# into the build tree in the configuration step, to avoid that the source tree
+# is polluted by result files when executing the tests.
+################################################################################
+
 # List all the tests that you want to execute as regression tests here
 set ( TEST_DIRS FreeFallTriad SimplePendulum MassSpring BeamModes
                 ConstantCurrent AddedMass InternalFluid
@@ -21,10 +29,10 @@ endif ( USE_CONCURRENT_RECOVERY )
 
 if ( WIN )
   find_file ( BarElm_LIBRARY NAMES BarElm.dll
-              PATHS ${FTREL_FTPLUGINROOT}/plugin/FTplugins/bin )
+              PATHS $ENV{FEDEM_PLUGIN} ${CMAKE_INSTALL_PREFIX}/bin/Plugin )
 else ( WIN )
   find_library ( BarElm_LIBRARY NAMES BarElm
-                 PATHS ${FTREL_FTPLUGINROOT}/plugin/FTplugins/lib )
+                 PATHS $ENV{FEDEM_PLUGIN} ${CMAKE_INSTALL_PREFIX}/bin/Plugin )
 endif ( WIN )
 if ( BarElm_LIBRARY )
   message ( STATUS "Found plugin: ${BarElm_LIBRARY}" )
@@ -62,25 +70,24 @@ set ( SOLVER ${VALGRIND_CMD} ../../../fedem_solver )
 
 add_custom_target ( copy_test_input_files )
 foreach ( TEST ${TEST_DIRS} )
-  set ( CMAKE_LISTS ${CMAKE_CURRENT_SOURCE_DIR}/TimeDomain/${TEST}/CMakeLists.txt )
-  if ( EXISTS ${CMAKE_LISTS} )
-    add_subdirectory ( TimeDomain/${TEST} ${CMAKE_CURRENT_BINARY_DIR}/${TEST} )
-  elseif ( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/FrequencyDomain/${TEST}/CMakeLists.txt )
-    add_subdirectory ( FrequencyDomain/${TEST} ${CMAKE_CURRENT_BINARY_DIR}/${TEST} )
+  set ( BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TEST} )
+  set ( CML_TDA ${CMAKE_CURRENT_SOURCE_DIR}/TimeDomain/${TEST}/CMakeLists.txt )
+  set ( CML_FDA ${CMAKE_CURRENT_SOURCE_DIR}/FrequencyDomain/${TEST}/CMakeLists.txt )
+  if ( EXISTS ${CML_TDA} )
+    set ( SRC_DIR TimeDomain/${TEST} )
+  elseif ( EXISTS ${CML_FDA} AND FFT_LIBRARY )
+    set ( SRC_DIR FrequencyDomain/${TEST} )
   elseif ( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${TEST}/CMakeLists.txt )
-    add_subdirectory ( ${TEST} )
-  else ( EXISTS ${CMAKE_LISTS} )
-    continue ( TEST ${TEST_DIRS} )
-  endif ( EXISTS ${CMAKE_LISTS} )
+    set ( SRC_DIR ${TEST} )
+  else ( EXISTS ${CML_TDA} )
+    continue ()
+  endif ( EXISTS ${CML_TDA} )
+  add_subdirectory ( ${SRC_DIR} ${BIN_DIR} )
+  set ( SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${SRC_DIR} )
   add_custom_command ( TARGET copy_test_input_files
-                       COMMAND ${CMAKE_COMMAND} -E copy_directory
-                               ${CMAKE_CURRENT_SOURCE_DIR}/${TEST}
-                               ${CMAKE_CURRENT_BINARY_DIR}/${TEST} )
+                       COMMAND ${CMAKE_COMMAND} -E copy_directory ${SRC_DIR} ${BIN_DIR} )
   add_custom_command ( TARGET copy_test_input_files
                        COMMAND ${CMAKE_COMMAND} -E remove -f
-                               ${CMAKE_CURRENT_BINARY_DIR}/${TEST}/*.md
-                               ${CMAKE_CURRENT_BINARY_DIR}/${TEST}/CMakeLists.*
-                               ${CMAKE_CURRENT_BINARY_DIR}/${TEST}/*/*.md
-                               ${CMAKE_CURRENT_BINARY_DIR}/${TEST}/*/*.png
-                               ${CMAKE_CURRENT_BINARY_DIR}/${TEST}/*/CMakeLists.* )
+                       ${BIN_DIR}/*.md ${BIN_DIR}/CMakeLists.*
+                       ${BIN_DIR}/*/*.md ${BIN_DIR}/*/*.png ${BIN_DIR}/*/CMakeLists.* )
 endforeach ( TEST ${TEST_DIRS} )

--- a/FrequencyDomain/Frame/CMakeLists.txt
+++ b/FrequencyDomain/Frame/CMakeLists.txt
@@ -4,15 +4,15 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "FreqDomainFrame" )
+set ( TEST_ID Frame )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ../../../../fedem_solver
+add_test ( NAME ${TEST_ID}-FDA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc 1.0e-6 )
 
-add_test ( ${TEST_ID}-TDA ../../../../fedem_solver
+add_test ( NAME ${TEST_ID}-TDA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -frequency_domain- -fsi2file motion.fsi
-	   -timeEnd 1.0 -timeInc 0.001 -curvePlotFile outputs.asc
+           -timeEnd 1.0 -timeInc 0.001 -curvePlotFile outputs.asc
            -verify exported_curves.asc 0.01 25 )

--- a/FrequencyDomain/RobotArm/CMakeLists.txt
+++ b/FrequencyDomain/RobotArm/CMakeLists.txt
@@ -4,11 +4,11 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "FreqDomainRobot" )
+set ( TEST_ID RobotArm )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ../../../../fedem_solver
+add_test ( NAME ${TEST_ID}-FDA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc 1.0e-6 )
 

--- a/FrequencyDomain/SpringDamper/CMakeLists.txt
+++ b/FrequencyDomain/SpringDamper/CMakeLists.txt
@@ -4,10 +4,10 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "FreqDomainSpringDamper" )
+set ( TEST_ID SpringDamper )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ../../../../fedem_solver
+add_test ( NAME ${TEST_ID}-FDA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc 1.0e-6 )

--- a/FrequencyDomain/Sweep/CMakeLists.txt
+++ b/FrequencyDomain/Sweep/CMakeLists.txt
@@ -4,15 +4,15 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "FreqDomainSweep" )
+set ( TEST_ID Sweep )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ../../../../fedem_solver
+add_test ( NAME ${TEST_ID}-FDA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc 1.0e-4 )
 
-add_test ( ${TEST_ID}-TDA ../../../../fedem_solver
+add_test ( NAME ${TEST_ID}-TDA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -frequency_domain- -fsi2file motion.fsi
-	   -timeEnd 3.9 -timeInc 0.001 -curvePlotFile outputs.asc
+           -timeEnd 3.9 -timeInc 0.001 -curvePlotFile outputs.asc
            -verify exported_curves.asc 0.01 25 )

--- a/FrequencyDomain/Tower/CMakeLists.txt
+++ b/FrequencyDomain/Tower/CMakeLists.txt
@@ -4,10 +4,10 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "FreqDomainTower" )
+set ( TEST_ID Tower )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ../../../../fedem_solver
+add_test ( NAME ${TEST_ID}-FDA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc 1.0e-6 )

--- a/TimeDomain/AW-N80-80-Windturbine/CMakeLists.txt
+++ b/TimeDomain/AW-N80-80-Windturbine/CMakeLists.txt
@@ -11,7 +11,7 @@ if ( BUILD_DUMMY_SUPEL_DLL )
 # Build the model-dependent shared library vpmSupEls
 
 if ( LINUX )
-  set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-2048" )
+  string ( APPEND CMAKE_Fortran_FLAGS " -ffree-line-length-2048" )
   set ( LIB_NAME libvpmSupEls.so )
 endif ( LINUX )
 
@@ -29,7 +29,7 @@ endif ( LINUX )
 
 # Now set up the actual test
 
-add_test ( WindTurbine-restart ../../test_restart
+add_test ( NAME WindTurbine-restart COMMAND test_restart
            -fco Setup.fco -fsifile Model-gen.fsi -fsi2file Gages.fsi
            -verify Responses.asc 1.0e-4
            -output 155 156 153 154 135 136 139 140 143 144
@@ -48,11 +48,11 @@ elseif ( FT_LARGE_MODELS )
 
 # Reduce the base FE part
 
-add_test ( N80-base ../../../../vpmReducer/fedem_reducer -fco N80-base.fco )
+add_test ( NAME N80-base COMMAND fedem_reducer -fco N80-base.fco )
 
 # Run the solver test using the freshly reduced superelement instead
 
-add_test ( WindTurbine-refresh ../../test_restart
+add_test ( NAME WindTurbine-refresh COMMAND test_restart
            -fco Setup.fco -recovery 2 -fsifile Model.fsi -fsi2file Gages.fsi
            -verify Responses.asc 1.0e-4
            -output 155 156 153 154 135 136 139 140 143 144

--- a/TimeDomain/AddedMass/CMakeLists.txt
+++ b/TimeDomain/AddedMass/CMakeLists.txt
@@ -4,11 +4,11 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "AddedMass" )
+set ( TEST_ID AddedMass )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file Clean.fsi
            -curvePlotFile outputs.asc -verify Deflection.asc 0.001 10 )
 
@@ -18,7 +18,8 @@ if ( BarElm_LIBRARY )
   # It should yield identical results as with the original beam element.
   message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Bar" )
 
-  add_test ( ${TEST_ID}-Bar ${SOLVER} -plugin ${BarElm_LIBRARY}
+  add_test ( NAME ${TEST_ID}-Bar COMMAND ${VALGRIND_CMD} fedem_solver
+             -plugin ${BarElm_LIBRARY}
              -fco Setup.fco -fsifile Model-bar.fsi -curveFile SubmergedBar.fmm
              -curvePlotFile outputs-bar.asc -verify outputs.asc 1.0e-6 )
 
@@ -28,6 +29,6 @@ endif ( BarElm_LIBRARY )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-MG" )
 
-add_test ( ${TEST_ID}-MG ${SOLVER}
+add_test ( NAME ${TEST_ID}-MG COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file MarineGrowth.fsi
            -curvePlotFile outputs.asc -verify Deflection_MarineGrowth.asc 1.0e-6 )

--- a/TimeDomain/BeamModes/CMakeLists.txt
+++ b/TimeDomain/BeamModes/CMakeLists.txt
@@ -4,13 +4,13 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "BeamModes" )
+set ( TEST_ID BeamModes )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER}
-           -fco Setup.fco -curvePlotFile outputs.asc
-           -verify dry_modes.asc 1.0e-3 )
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
+           -fco Setup.fco
+           -curvePlotFile outputs.asc -verify dry_modes.asc 1.0e-3 )
 
 if ( BarElm_LIBRARY )
 
@@ -19,7 +19,8 @@ if ( BarElm_LIBRARY )
   # beam element, due to the total lack of bending stiffness.
   message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Bar" )
 
-  add_test ( ${TEST_ID}-Bar ${SOLVER} -plugin ${BarElm_LIBRARY}
+  add_test ( NAME ${TEST_ID}-Bar COMMAND ${VALGRIND_CMD} fedem_solver
+             -plugin ${BarElm_LIBRARY}
              -fco Setup.fco -fsifile Model-bar.fsi
              -curvePlotFile outputs.asc -verify bar-modes.asc 1.0e-6 )
 
@@ -27,9 +28,9 @@ endif ( BarElm_LIBRARY )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Wet" )
 
-add_test ( ${TEST_ID}-Wet ${SOLVER}
-           -fco Setup.fco -fsi2file Water.fsi -curvePlotFile outputs.asc
-           -verify wet_modes.asc 1.0e-3 )
+add_test ( NAME ${TEST_ID}-Wet COMMAND ${VALGRIND_CMD} fedem_solver
+           -fco Setup.fco -fsi2file Water.fsi
+           -curvePlotFile outputs.asc -verify wet_modes.asc 1.0e-3 )
 
 if ( BarElm_LIBRARY )
 
@@ -38,7 +39,8 @@ if ( BarElm_LIBRARY )
   # beam element, due to the total lack of bending stiffness.
   message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-WetBar" )
 
-  add_test ( ${TEST_ID}-WetBar ${SOLVER} -plugin ${BarElm_LIBRARY}
+  add_test ( NAME ${TEST_ID}-WetBar COMMAND ${VALGRIND_CMD} fedem_solver
+             -plugin ${BarElm_LIBRARY}
              -fco Setup.fco -fsifile Model-bar.fsi -fsi2file Water.fsi
              -curvePlotFile outputs.asc -verify wetbar-modes.asc 1.0e-6 )
 

--- a/TimeDomain/CamJoint/CMakeLists.txt
+++ b/TimeDomain/CamJoint/CMakeLists.txt
@@ -4,15 +4,15 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "CamJoint" )
+set ( TEST_ID CamJoint )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Damping" )
 
-add_test ( ${TEST_ID}-Damping ${SOLVER}
+add_test ( NAME ${TEST_ID}-Damping COMMAND fedem_solver
            -fco CamWithDamping.fco -curvePlotFile outputs.asc -terminal -1
            -verify CamWithDamping.asc 1.0e-5 )
 
-add_test ( ${TEST_ID}-DefDamping ${SOLVER}
+add_test ( NAME ${TEST_ID}-DefDamping COMMAND fedem_solver
            -fco CamWithDamping.fco -curvePlotFile outputs.asc -terminal -1
            -fsifile CamWithDefDamping.fsi -curveFile "CamWithDeformDamping.fmm"
            -verify slide_damping.asc 5.0e-4 )
@@ -23,15 +23,19 @@ if ( NOT FT_LARGE_MODELS )
   set ( END_TIME -timeEnd 0.1 )
 endif ( NOT FT_LARGE_MODELS )
 
-add_test ( ${TEST_ID}-Pear ${SOLVER}
+add_test ( NAME ${TEST_ID}-Pear COMMAND fedem_solver
            -fco Setup.fco ${END_TIME} -allSecondaryVars
            -curvePlotFile outputs.asc -terminal -1
            -verify SystemEnergy_R253.asc 0.05 )
 
-add_test ( ${TEST_ID}-Cam   ${REDUCE} -fco cam.fco -terminal -1 )
-add_test ( ${TEST_ID}-Axle  ${REDUCE} -fco axle.fco -terminal -1 )
-add_test ( ${TEST_ID}-Wheel ${REDUCE} -fco wheel.fco -terminal -1 )
-add_test ( ${TEST_ID}-Beam  ${REDUCE} -fco beam.fco -terminal -1 )
+add_test ( NAME ${TEST_ID}-Cam   COMMAND fedem_reducer
+           -fco cam.fco -terminal -1 )
+add_test ( NAME ${TEST_ID}-Axle  COMMAND fedem_reducer
+           -fco axle.fco -terminal -1 )
+add_test ( NAME ${TEST_ID}-Wheel COMMAND fedem_reducer
+           -fco wheel.fco -terminal -1 )
+add_test ( NAME ${TEST_ID}-Beam  COMMAND fedem_reducer
+           -fco beam.fco -terminal -1 )
 
 # Ensure the FE part reduction is performed before the dynamics simulation
 set_tests_properties ( ${TEST_ID}-Pear PROPERTIES DEPENDS ${TEST_ID}-Cam )

--- a/TimeDomain/Cantilever-extFunc/CMakeLists.txt
+++ b/TimeDomain/Cantilever-extFunc/CMakeLists.txt
@@ -5,22 +5,24 @@
 # This file is part of FEDEM - https://openfedem.org
 
 set ( TEST_ID ExtFunc )
-set ( TEST_CMD ${VALGRIND_CMD} ../../test_external )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
-add_test ( ${TEST_ID} ${TEST_CMD} -fco Setup.fco -fsi Model.fsi
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} test_external
+           -fco Setup.fco -fsi Model.fsi
            -verify TipPosition.asc 1.0e-8
            -input 2 -output 3 4 5 -writeExtFunc extfuncval.dat )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-window" )
-add_test ( ${TEST_ID}-window ${TEST_CMD} -fco Setup.fco -fsi Model.fsi
+add_test ( NAME ${TEST_ID}-window COMMAND ${VALGRIND_CMD} test_external
+           -fco Setup.fco -fsi Model.fsi
            -verify TipPosition.asc ${FT_TOLERANCE}
            -input 2 -output 3 4 5 -Window )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-file" )
-add_test ( ${TEST_ID}-file ${SOLVER} -fco Setup.fco -fsifile Model.fsi -allTriadVars
-           -externalfuncfile extfuncval.dat -curvePlotFile outputvalues.asc
+add_test ( NAME ${TEST_ID}-file COMMAND ${VALGRIND_CMD} fedem_solver
+           -fco Setup.fco -fsifile Model.fsi -allTriadVars
+           -externalfuncfile extfuncval.dat
            -curveFile Cantilever-internal.fmm -curvePlotType 5 -curvePlotPrec 1
-           -verify TipPosition.asc 1.0e-9 )
+           -curvePlotFile outputvalues.asc -verify TipPosition.asc 1.0e-9 )
 
 set_tests_properties ( ${TEST_ID}-file PROPERTIES DEPENDS ${TEST_ID} )

--- a/TimeDomain/CarSuspension/CMakeLists.txt
+++ b/TimeDomain/CarSuspension/CMakeLists.txt
@@ -4,17 +4,20 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "CarSuspension" )
+set ( TEST_ID CarSuspension )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc -terminal -1
            -verify exported_curves.asc 1.0e-4 )
 
-add_test ( ${TEST_ID}-LCA     ${REDUCE} -fco lca.fco -terminal -1 )
-add_test ( ${TEST_ID}-UCA     ${REDUCE} -fco uca.fco -terminal -1 )
-add_test ( ${TEST_ID}-Knuckle ${REDUCE} -fco knuckle.fco -terminal -1 )
+add_test ( NAME ${TEST_ID}-LCA COMMAND ${VALGRIND_CMD} fedem_reducer
+           -fco lca.fco -terminal -1 )
+add_test ( NAME ${TEST_ID}-UCA COMMAND ${VALGRIND_CMD} fedem_reducer
+           -fco uca.fco -terminal -1 )
+add_test ( NAME ${TEST_ID}-Knuckle COMMAND ${VALGRIND_CMD} fedem_reducer
+           -fco knuckle.fco -terminal -1 )
 
 # Ensure the FE part reduction is performed before the dynamics simulation
 set_tests_properties ( ${TEST_ID} PROPERTIES DEPENDS ${TEST_ID}-Knuckle )

--- a/TimeDomain/ConstantCurrent/CMakeLists.txt
+++ b/TimeDomain/ConstantCurrent/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "ConstantCurrent" )
+set ( TEST_ID ConstantCurrent )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
@@ -12,6 +12,6 @@ if ( NOT FT_LARGE_MODELS )
   set ( END_TIME -timeEnd 1 )
 endif ( NOT FT_LARGE_MODELS )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND fedem_solver
            -fco Setup.fco ${END_TIME} -curvePlotFile outputs.asc
            -verify exported_curves.asc 1.0e-6 )

--- a/TimeDomain/DampedOscillator/CMakeLists.txt
+++ b/TimeDomain/DampedOscillator/CMakeLists.txt
@@ -4,12 +4,12 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "DampedOscillator" )
+set ( TEST_ID DampedOscillator )
 
 # The original test (old HHT procedure)
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT" )
 
-add_test ( ${TEST_ID}-HHT ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file linear-damper.fsi
            -curvePlotFile outputHHT.asc
            -verify linear-damper.asc ${FT_TOLERANCE} )
@@ -17,7 +17,7 @@ add_test ( ${TEST_ID}-HHT ${SOLVER}
 # Test using true inertia force (FIactual) in residual calculation
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT1" )
 
-add_test ( ${TEST_ID}-HHT1 ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT1 COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file linear-damper.fsi -NewmarkFlag 1
            -curvePlotFile outputHHT1.asc
            -verify linear-damper1.asc ${FT_TOLERANCE} )
@@ -26,7 +26,7 @@ add_test ( ${TEST_ID}-HHT1 ${SOLVER}
 # and consistent damping force calculation in the predictor step
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT2" )
 
-add_test ( ${TEST_ID}-HHT2 ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT2 COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file linear-damper.fsi -NewmarkFlag 2
            -curvePlotFile outputHHT2.asc
            -verify linear-damper1.asc ${FT_TOLERANCE} )
@@ -34,7 +34,7 @@ add_test ( ${TEST_ID}-HHT2 ${SOLVER}
 # Test using new HHT implementation (with consistent predictor)
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT100" )
 
-add_test ( ${TEST_ID}-HHT100 ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT100 COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file linear-damper.fsi -NewmarkFlag 100
            -curvePlotFile outputHHT100.asc
            -verify linear-damper1.asc ${FT_TOLERANCE} )
@@ -43,7 +43,7 @@ add_test ( ${TEST_ID}-HHT100 ${SOLVER}
 # Should give identical response as HHT100.
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-GA" )
 
-add_test ( ${TEST_ID}-GA ${SOLVER}
+add_test ( NAME ${TEST_ID}-GA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file linear-damper.fsi -NewmarkFlag 200
            -curvePlotFile outputGA.asc
            -verify outputHHT100.asc ${FT_TOLERANCE} )
@@ -52,7 +52,7 @@ add_test ( ${TEST_ID}-GA ${SOLVER}
 # Minor discrepancies are expected.
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-GA04" )
 
-add_test ( ${TEST_ID}-GA04 ${SOLVER}
+add_test ( NAME ${TEST_ID}-GA04 COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file linear-damper.fsi -NewmarkFlag 200 -alphaNewmark -0.4 0.2
            -curvePlotFile outputGA04.asc
            -verify outputHHT100.asc 0.002 100 )
@@ -63,7 +63,7 @@ set_tests_properties ( ${TEST_ID}-GA PROPERTIES DEPENDS ${TEST_ID}-HHT100 )
 # Test dynamic ramp-up of gravity and external load
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-ramp" )
 
-add_test ( ${TEST_ID}-ramp ${SOLVER}
+add_test ( NAME ${TEST_ID}-ramp COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fao Ramp.fao -fsi2file linear-damper+grav.fsi
            -curvePlotFile outputRamp.asc -curveFile "Oscillator-ramped.fmm"
            -verify linear-damper-ramp.asc ${FT_TOLERANCE} )
@@ -75,12 +75,12 @@ add_test ( ${TEST_ID}-ramp ${SOLVER}
 # equivalent in such cases (i.e., with constant damping coefficient).
 #####################################################################
 
-set ( TEST_ID "${TEST_ID}-const" )
+set ( TEST_ID ${TEST_ID}-const )
 
 # The original test (old HHT procedure)
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT" )
 
-add_test ( ${TEST_ID}-HHT ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file constant-damper.fsi
            -curvePlotFile const-damperHHT.asc
            -verify constant-damper.asc ${FT_TOLERANCE} )
@@ -88,7 +88,7 @@ add_test ( ${TEST_ID}-HHT ${SOLVER}
 # Test using true inertia force (FIactual) in residual calculation
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT1" )
 
-add_test ( ${TEST_ID}-HHT1 ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT1 COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file constant-damper.fsi
            -NewmarkFlag 1 -curvePlotFile const-damperHHT1.asc
            -verify constant-damper1.asc ${FT_TOLERANCE} )
@@ -96,7 +96,7 @@ add_test ( ${TEST_ID}-HHT1 ${SOLVER}
 # Test using new HHT implementation (with consistent predictor)
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT100" )
 
-add_test ( ${TEST_ID}-HHT100 ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT100 COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file constant-damper.fsi
            -NewmarkFlag 100 -curvePlotFile const-damperHHT100.asc
            -verify const-damperHHT1.asc ${FT_TOLERANCE} )
@@ -105,7 +105,7 @@ add_test ( ${TEST_ID}-HHT100 ${SOLVER}
 # Should give identical response as HHT100.
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-GA" )
 
-add_test ( ${TEST_ID}-GA ${SOLVER}
+add_test ( NAME ${TEST_ID}-GA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -fsi2file constant-damper.fsi
            -NewmarkFlag 200 -curvePlotFile const-damperGA.asc
            -verify const-damperHHT1.asc ${FT_TOLERANCE} )

--- a/TimeDomain/FreeFallTriad/CMakeLists.txt
+++ b/TimeDomain/FreeFallTriad/CMakeLists.txt
@@ -4,10 +4,10 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "FreeFallTriad" )
+set ( TEST_ID FreeFallTriad )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc ${FT_TOLERANCE} )

--- a/TimeDomain/InternalFluid/CMakeLists.txt
+++ b/TimeDomain/InternalFluid/CMakeLists.txt
@@ -4,10 +4,10 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "InternalFluid" )
+set ( TEST_ID InternalFluid )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify Deflection.asc 0.001 10 )

--- a/TimeDomain/MassSpring/CMakeLists.txt
+++ b/TimeDomain/MassSpring/CMakeLists.txt
@@ -4,12 +4,12 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "MassSpring" )
+set ( TEST_ID MassSpring )
 
 # The original test (old HHT procedure)
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT" )
 
-add_test ( ${TEST_ID}-HHT ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc ${FT_TOLERANCE} )
 
@@ -17,7 +17,7 @@ add_test ( ${TEST_ID}-HHT ${SOLVER}
 # Only some small discrepancies are to be expected.
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-HHT1" )
 
-add_test ( ${TEST_ID}-HHT1 ${SOLVER}
+add_test ( NAME ${TEST_ID}-HHT1 COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -NewmarkFlag 1 -curvePlotFile outputHHT.asc
            -verify exported_curves.asc 0.015 )
 
@@ -25,7 +25,7 @@ add_test ( ${TEST_ID}-HHT1 ${SOLVER}
 # Should give identical response as HHT1 with 'true inertia' force.
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-GA" )
 
-add_test ( ${TEST_ID}-GA ${SOLVER}
+add_test ( NAME ${TEST_ID}-GA COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -NewmarkFlag 200 -curvePlotFile outputGA.asc
            -verify outputHHT.asc ${FT_TOLERANCE} )
 

--- a/TimeDomain/ParticleInWaves/CMakeLists.txt
+++ b/TimeDomain/ParticleInWaves/CMakeLists.txt
@@ -4,11 +4,11 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "ParticleInWaves" )
+set ( TEST_ID ParticleInWaves )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco
            -curvePlotFile outputs.asc -verify Deflection.asc 1.0e-6 )
 
@@ -18,8 +18,9 @@ if ( BarElm_LIBRARY )
   # It should yield identical results as with the original beam element.
   message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-Bar" )
 
-  add_test ( ${TEST_ID}-Bar ${SOLVER} -plugin ${BarElm_LIBRARY}
-	     -fco Setup.fco -fsifile Model-bar.fsi -timeEnd 5.0 -curveFile SmallBar.fmm
+  add_test ( NAME ${TEST_ID}-Bar COMMAND ${VALGRIND_CMD} fedem_solver
+             -plugin ${BarElm_LIBRARY}
+             -fco Setup.fco -fsifile Model-bar.fsi -curveFile SmallBar.fmm -timeEnd 5.0
              -curvePlotFile outputs-bar.asc -verify outputs.asc 5.0e-4 )
 
   set_tests_properties ( ${TEST_ID}-Bar PROPERTIES DEPENDS ${TEST_ID} )

--- a/TimeDomain/SimplePendulum/CMakeLists.txt
+++ b/TimeDomain/SimplePendulum/CMakeLists.txt
@@ -4,10 +4,10 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "SimplePendulum" )
+set ( TEST_ID SimplePendulum )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
            -fco Setup.fco -curvePlotFile outputs.asc
            -verify exported_curves.asc ${FT_TOLERANCE} )

--- a/TimeDomain/SoilDegradation/CMakeLists.txt
+++ b/TimeDomain/SoilDegradation/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "SoilDegradation" )
+set ( TEST_ID SoilDegradation )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
@@ -12,6 +12,6 @@ if ( NOT FT_LARGE_MODELS )
   set ( END_TIME -timeEnd 5 )
 endif ( NOT FT_LARGE_MODELS )
 
-add_test ( ${TEST_ID} ${SOLVER}
+add_test ( NAME ${TEST_ID} COMMAND fedem_solver
            -fco Setup.fco ${END_TIME} -curvePlotFile outputs.asc
            -verify exported_curves.asc 1.0e-5 )

--- a/TimeDomain/SubModelling/CMakeLists.txt
+++ b/TimeDomain/SubModelling/CMakeLists.txt
@@ -4,38 +4,35 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "SubModelling" )
+set ( TEST_ID SubModelling )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
 # Global model FE part reduction
-add_test ( ${TEST_ID}-reduce ${REDUCE} -terminal -1
-           -fco 01_01_Global_Coarse.fco )
+add_test ( NAME ${TEST_ID}-reduce COMMAND ${VALGRIND_CMD} fedem_reducer
+           -fco 01_01_Global_Coarse.fco -terminal -1 )
 
 # Global model system solve
 # with recovery of internal displacements and von Mises stress
 # on an element group, as well as strain gage recovery
-add_test ( ${TEST_ID}-global ${SOLVER} -terminal -1
-           -fco globalmodel.fco -curvePlotFile outputs.asc
-           -verify PrincipalStresses.asc 1.0e-5 )
+add_test ( NAME ${TEST_ID}-global COMMAND ${VALGRIND_CMD} fedem_solver
+           -fco globalmodel.fco -terminal -1
+           -curvePlotFile outputs.asc -verify PrincipalStresses.asc 1.0e-5 )
 
 # Redo the global model system solve
 # with recovery of internal displacements on the whole model,
 # and no von Mises stress calculation and no strain gage recovery.
 # Notice no result verification here, this test is only used to generate
 # input for the ${TEST_ID}-map2 test.
-add_test ( ${TEST_ID}-nogrp ${SOLVER} -terminal -1
-           -fco globalmodel.fco -fao globalmodel.fao )
+add_test ( NAME ${TEST_ID}-nogrp COMMAND ${VALGRIND_CMD} fedem_solver
+           -fco globalmodel.fco -fao globalmodel.fao -terminal -1 )
 
 if ( TARGET fedem_solmap )
   if ( TARGET check )
     add_dependencies ( check fedem_solmap )
   endif ( TARGET check )
 
-  if ( ${FT_TOLERANCE} EQUAL "0.0" )
-#   Check for exact match using cmake's internal file comparing command
-    set ( COMPARE ${CMAKE_COMMAND} -E compare_files )
-  else ( ${FT_TOLERANCE} EQUAL "0.0" )
+  if ( NOT ${FT_TOLERANCE} EQUAL "0.0" )
 #   Build a utility program comparing two binary fnd-files with some tolerance
     add_executable ( comp_fnd compareFnd.C )
     add_executable ( list_fnd listFnd.C )
@@ -44,47 +41,57 @@ if ( TARGET fedem_solmap )
     if ( TARGET check )
       add_dependencies ( check comp_fnd )
     endif ( TARGET check )
-    set ( COMPARE comp_fnd ${FT_TOLERANCE} )
-  endif ( ${FT_TOLERANCE} EQUAL "0.0" )
+  endif ( NOT ${FT_TOLERANCE} EQUAL "0.0" )
 
 # Map internal displacements at interface nodes to sub-model
-  add_test ( ${TEST_ID}-map ${SOLMAP} -fco glob2sub.fco )
+  add_test ( NAME ${TEST_ID}-map COMMAND ${VALGRIND_CMD} fedem_solmap
+            -fco glob2sub.fco )
 # Map internal displacements using the whole-model displacement file instead
-  add_test ( ${TEST_ID}-map2 ${SOLMAP} -mapFile 02_01_Submodel_Coarse.map
+  add_test ( NAME ${TEST_ID}-map2 COMMAND ${VALGRIND_CMD} fedem_solmap
+             -mapFile 02_01_Submodel_Coarse.map
              -frsFile 01_01_Global_deformation_1.frs -outFile submodel.fnd )
 # This should give identical results
-  add_test ( ${TEST_ID}-comp ${COMPARE} 02_01_Submodel_Coarse.fnd submodel.fnd )
+  if ( TARGET comp_fnd )
+    add_test ( NAME ${TEST_ID}-comp COMMAND comp_fnd ${FT_TOLERANCE}
+               02_01_Submodel_Coarse.fnd submodel.fnd )
+  else ( TARGET comp_fnd )
+#   Check for exact match using cmake's internal file comparing command
+    add_test ( ${TEST_ID}-comp ${CMAKE_COMMAND} -E compare_files
+               02_01_Submodel_Coarse.fnd submodel.fnd )
+  endif ( TARGET comp_fnd )
 # Map internal displacements including rotational DOFs
-  add_test ( ${TEST_ID}-rotmap ${SOLMAP} -fco glob2sub-rot.fco )
+  add_test ( NAME ${TEST_ID}-rotmap COMMAND ${VALGRIND_CMD} fedem_solmap
+             -fco glob2sub-rot.fco )
   if ( FT_LARGE_MODELS )
 #   Map internal displacements at interface nodes to fine sub-model
-    add_test ( ${TEST_ID}-mapfine ${SOLMAP} -fco glob2sub-fine.fco )
+    add_test ( NAME ${TEST_ID}-mapfine COMMAND fedem_solmap
+               -fco glob2sub-fine.fco )
   endif ( FT_LARGE_MODELS )
 
 # Sub-model FE part reduction
-  add_test ( ${TEST_ID}-redsub ${REDUCE} -terminal -1
-             -fco 02_01_Submodel_Coarse.fco )
+  add_test ( NAME ${TEST_ID}-redsub COMMAND fedem_reducer
+             -fco 02_01_Submodel_Coarse.fco -terminal -1 )
   if ( FT_LARGE_MODELS )
-    add_test ( ${TEST_ID}-redfine ${REDUCE} -terminal -1
-               -fco 02_02_Submodel_Fine.fco )
+    add_test ( NAME ${TEST_ID}-redfine COMMAND fedem_reducer
+               -fco 02_02_Submodel_Fine.fco -terminal -1 )
   endif ( FT_LARGE_MODELS )
 
 # Sub-model system solve with strain gage recovery
-  add_test ( ${TEST_ID} ${SOLVER} -terminal -1
-             -fco submodel.fco -curvePlotFile outputs.asc
-             -verify PrincipalStresses.asc 0.018 )
+  add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
+             -fco submodel.fco -terminal -1
+             -curvePlotFile outputs.asc -verify PrincipalStresses.asc 0.018 )
 
 # Sub-model system solve with strain gage recovery
 # including prescribed rotations at interface nodes
-  add_test ( ${TEST_ID}-rot ${SOLVER} -terminal -1
-             -fco submodel.fco -fao submodel.fao -curvePlotFile outputs-rot.asc
-             -verify PrincipalStresses.asc 0.014 )
+  add_test ( NAME ${TEST_ID}-rot COMMAND ${VALGRIND_CMD} fedem_solver
+             -fco submodel.fco -fao submodel.fao -terminal -1
+             -curvePlotFile outputs-rot.asc -verify PrincipalStresses.asc 0.014 )
 
   if ( FT_LARGE_MODELS )
 #   Fine sub-model system solve with strain gage recovery
-    add_test ( ${TEST_ID}-fine ${SOLVER} -terminal -1
-               -fco submodel-fine.fco -curvePlotFile outputs.asc
-               -verify PrincipalStresses.asc 0.08 )
+    add_test ( NAME ${TEST_ID}-fine COMMAND fedem_solver
+               -fco submodel-fine.fco -terminal -1
+               -curvePlotFile outputs.asc -verify PrincipalStresses.asc 0.08 )
   endif ( FT_LARGE_MODELS )
 
 # Ensure the processes are performed in the right order

--- a/TimeDomain/SubModelling/GroupBmat/CMakeLists.txt
+++ b/TimeDomain/SubModelling/GroupBmat/CMakeLists.txt
@@ -4,28 +4,19 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "GroupBmat" )
-
-set ( PSOLVE ${VALGRIND_CMD} ../../../../../vpmReducer/fedem_partsol )
-set ( REDUCE ${VALGRIND_CMD} ../../../../../vpmReducer/fedem_reducer )
-set ( SOLMAP ${VALGRIND_CMD} ../../../../../SolutionMapper/fedem_solmap )
-set ( SOLVER ${VALGRIND_CMD} ../../../../fedem_solver )
+set ( TEST_ID GroupBmat )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
 # Global model direct solve
-add_test ( ${TEST_ID}-glb ${PSOLVE}
+add_test ( NAME ${TEST_ID}-glb COMMAND ${VALGRIND_CMD} fedem_partsol
            -linkFile 01_01_Global_Coarse.ftl
            -frsFile  01_01_Global_Coarse.frs )
 
 if ( TARGET fedem_solmap )
 
-  if ( NOT ${FT_TOLERANCE} EQUAL "0.0" )
-    set ( COMPARE ../comp_fnd 1.0e-8 )
-  endif ( NOT ${FT_TOLERANCE} EQUAL "0.0" )
-
 # Map internal displacements at interface nodes to sub-model
-  add_test ( ${TEST_ID}-map ${SOLMAP}
+  add_test ( NAME ${TEST_ID}-map COMMAND ${VALGRIND_CMD} fedem_solmap
              -nodeFile ../02_01_Submodel_Coarse_Nodes.dat
              -subFile  ../02_01_Submodel_Coarse.nas
              -ftlFile 01_01_Global_Coarse.ftl
@@ -33,7 +24,7 @@ if ( TARGET fedem_solmap )
              -outFile 02_01_Submodel_Coarse.fnd )
 
 # Sub-model FE part reduction
-  add_test ( ${TEST_ID}-red ${REDUCE} -noGrav
+  add_test ( NAME ${TEST_ID}-red COMMAND ${VALGRIND_CMD} fedem_reducer -noGrav
              -linkfile 02_01_Submodel_Coarse.ftl
              -Bmatfile 02_01_Submodel_Coarse_B.fmx
              -samfile  02_01_Submodel_Coarse_SAM.fsm
@@ -41,19 +32,20 @@ if ( TARGET fedem_solmap )
              -resfile  02_01_Submodel_Coarse.res )
 
 # Sub-model system solve with displacement recovery on element group
-  add_test ( ${TEST_ID}-sub ${SOLVER} -fco solver.fco
-             -fsifile submodel.fsi -resfile submodelG.res
+  add_test ( NAME ${TEST_ID}-sub COMMAND ${VALGRIND_CMD} fedem_solver
+             -fco solver.fco -fsifile submodel.fsi -resfile submodelG.res
              -displacementfile 02_01_Submodel_Coarse.fnd
              -frs3file 02_01_Submodel_Group.frs )
 
 # Sub-model system solve with displacement recovery on whole model
-  add_test ( ${TEST_ID}-whl ${SOLVER} -fco solver.fco -recovery 11
+  add_test ( NAME ${TEST_ID}-whl COMMAND ${VALGRIND_CMD} fedem_solver
+             -fco solver.fco -recovery 11
              -fsifile submodel.fsi -resfile submodelA.res
              -displacementfile 02_01_Submodel_Coarse.fnd
              -frs3file 02_01_Submodel_All.frs )
 
 # Map internal displacements at interface nodes to sub-sub-model
-  add_test ( ${TEST_ID}-map2 ${SOLMAP}
+  add_test ( NAME ${TEST_ID}-map2 COMMAND ${VALGRIND_CMD} fedem_solmap
              -nodeFile subsubnodes.dat
              -subFile  subsubmodel.ftl
              -mapFile  subsubmodel.map
@@ -62,14 +54,20 @@ if ( TARGET fedem_solmap )
              -outFile  02_01_Submodel_Group.fnd )
 
 # Map internal displacements using the whole-model displacement file instead
-  add_test ( ${TEST_ID}-map3 ${SOLMAP}
+  add_test ( NAME ${TEST_ID}-map3 COMMAND ${VALGRIND_CMD} fedem_solmap
              -mapFile  subsubmodel.map
              -frsFile  02_01_Submodel_All_1.frs
              -outFile  02_01_Submodel_All.fnd )
 
 # This should give identical results
-  add_test ( ${TEST_ID}-comp ${COMPARE}
-             02_01_Submodel_Group.fnd 02_01_Submodel_All.fnd )
+  if ( TARGET comp_fnd )
+    add_test ( NAME ${TEST_ID}-comp COMMAND comp_fnd 1.0e-8
+               02_01_Submodel_Group.fnd 02_01_Submodel_All.fnd )
+  else ( TARGET comp_fnd )
+#   Check for exact match using cmake's internal file comparing command
+    add_test ( ${TEST_ID}-comp ${CMAKE_COMMAND} -E compare_files
+               02_01_Submodel_Group.fnd 02_01_Submodel_All.fnd )
+  endif ( TARGET comp_fnd )
 
 # Ensure the processes are performed in the right order
   set_tests_properties ( ${TEST_ID}-comp PROPERTIES DEPENDS ${TEST_ID}-map3 )

--- a/TimeDomain/UserDefinedBar/CMakeLists.txt
+++ b/TimeDomain/UserDefinedBar/CMakeLists.txt
@@ -4,26 +4,29 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "UserDefinedBar" )
+set ( TEST_ID UserDefinedBar )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER} -plugin ${BarElm_LIBRARY}
-           -fco Setup.fco -curvePlotFile outputs.asc
-           -verify exported-damped.asc 2.0e-5 )
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
+           -plugin ${BarElm_LIBRARY}
+           -fco Setup.fco
+           -curvePlotFile outputs.asc -verify exported-damped.asc 2.0e-5 )
 
-set ( TEST_ID "MooringLine" )
-
-message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
-
-add_test ( ${TEST_ID} ${SOLVER} -plugin ${BarElm_LIBRARY}
-           -fco MooringLine.fco -curvePlotFile outputs.asc
-           -verify MooringLine.asc 1.0e-6 10 )
-
-set ( TEST_ID "MooringWindup" )
+set ( TEST_ID MooringLine )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
 
-add_test ( ${TEST_ID} ${SOLVER} -plugin ${BarElm_LIBRARY}
-           -fco Windup.fco -curvePlotFile outputs.asc
-           -verify Windup.asc 1.0e-6 )
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
+           -plugin ${BarElm_LIBRARY}
+           -fco MooringLine.fco
+           -curvePlotFile outputs.asc -verify MooringLine.asc 1.0e-6 10 )
+
+set ( TEST_ID MooringWindup )
+
+message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}" )
+
+add_test ( NAME ${TEST_ID} COMMAND ${VALGRIND_CMD} fedem_solver
+           -plugin ${BarElm_LIBRARY}
+           -fco Windup.fco
+           -curvePlotFile outputs.asc -verify Windup.asc 1.0e-6 )

--- a/TimeDomain/WindTurbine/CMakeLists.txt
+++ b/TimeDomain/WindTurbine/CMakeLists.txt
@@ -4,15 +4,16 @@
 #
 # This file is part of FEDEM - https://openfedem.org
 
-set ( TEST_ID "WindTurbine" )
+set ( TEST_ID WindTurbine )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-fixed" )
 
 if ( NOT FT_LARGE_MODELS )
+  set ( VALG_CMD ${VALGRIND_CMD} )
   set ( END_TIME -timeEnd 1 )
 endif ( NOT FT_LARGE_MODELS )
 
-add_test ( ${TEST_ID}-fixed ${SOLVER}
+add_test ( NAME ${TEST_ID}-fixed COMMAND ${VALG_CMD} fedem_solver
            -fco Setup.fco ${END_TIME} -curvePlotFile outputs.asc
            -verify bladeroot-forces-fixed.asc 0.002 1007 )
 
@@ -22,7 +23,7 @@ if ( FT_LARGE_MODELS )
   set ( END_TIME -timeEnd 10 )
 endif ( FT_LARGE_MODELS )
 
-add_test ( ${TEST_ID}-modes ${SOLVER}
+add_test ( NAME ${TEST_ID}-modes COMMAND ${VALG_CMD} fedem_soler
            -fco Setup.fco -fop EigenValues.fop ${END_TIME}
            -curvePlotFile outputs.asc
            -curveFile EigenValues.fmm -verify eigenvalues.asc 0.001 )
@@ -31,7 +32,7 @@ if ( FT_LARGE_MODELS )
 
 message ( STATUS "INFORMATION : Adding regression test ${TEST_ID}-rotating" )
 
-add_test ( ${TEST_ID}-rotating ${SOLVER}
+add_test ( NAME ${TEST_ID}-rotating COMMAND fedem_solver
            -fco Setup.fco -fsifile Model-light.fsi -timeEnd 150
            -curvePlotFile outputs.asc -curveFile WindTurbine-prescrvel.fmm
            -verify bladeroot-forces.asc 0.0025 4007 )


### PR DESCRIPTION
Using `add_test ( NAME <test_name> COMMAND <test_command> )` instead of just `add_test ( <test_name <test_command> )` such that the paths to the build targets are expanded properly and w don't need to rely on explicit relative paths.

Also some fixes in the top-level CMakeLists.txt file on the copying of input files to build tree.